### PR TITLE
Fix caching

### DIFF
--- a/lib/px/service/client/caching.rb
+++ b/lib/px/service/client/caching.rb
@@ -73,7 +73,7 @@ module Px::Service::Client
           raise ArgumentError.new('Block did not return a Future.') unless retry_response.is_a?(Future)
           resp = retry_response.value!
 
-          entry = CacheEntry.new(config.cache_client, url, policy_group, resp.options)
+          entry = CacheEntry.new(config.cache_client, url, policy_group, resp)
 
           # Only store a new result if we roll a 0
           r = rand(refresh_probability)
@@ -119,8 +119,7 @@ module Px::Service::Client
         begin
           raise ArgumentError.new('Block did not return a Future.') unless retry_response.is_a?(Future)
           resp = retry_response.value!
-          
-          entry = CacheEntry.new(config.cache_client, url, policy_group, resp.options)
+          entry = CacheEntry.new(config.cache_client, url, policy_group, resp)
           entry.store(expires_in)
           resp
         rescue Px::Service::ServiceError => ex

--- a/lib/px/service/client/version.rb
+++ b/lib/px/service/client/version.rb
@@ -1,7 +1,7 @@
 module Px
   module Service
     module Client
-      VERSION = "1.2.2"
+      VERSION = "1.2.3"
     end
   end
 end


### PR DESCRIPTION
https://app.asana.com/0/91022952775005/134167581290024

The previous code expects a `Typhoeus::response` which has a `options` method. It should cache the response instead. 

Also, `cache_request` should not return a `Typhoeus::request`. 

Tested with `web-bff` and `px-search-service-client` in my local dev. The correct response body was cached in a memcached entry. 

@cdmicacc please inspect

Will upload the gem once this PR is approved.