### PR TITLE
Better error handling in future

### DIFF
--- a/lib/px/service/client/future.rb
+++ b/lib/px/service/client/future.rb
@@ -15,11 +15,12 @@ module Px::Service::Client
 
       if block_given?
         Fiber.new do
-          begin
-            complete(yield)
+          value = begin
+            yield
           rescue Exception => ex
-            complete(ex)
+            ex
           end
+          complete(value)
         end.resume
       end
     end

--- a/lib/px/service/client/version.rb
+++ b/lib/px/service/client/version.rb
@@ -1,7 +1,7 @@
 module Px
   module Service
     module Client
-      VERSION = "2.0.5"
+      VERSION = "2.0.6"
     end
   end
 end

--- a/px-service-client.gemspec
+++ b/px-service-client.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |spec|
   spec.name          = "px-service-client"
   spec.version       = Px::Service::Client::VERSION
   spec.summary       = %q{Common service client behaviours for Ruby applications}
-  spec.authors       = ["Chris Micacchi"]
-  spec.email         = ["chris@500px.com"]
+  spec.authors       = ["Chris Micacchi", "Zimu Liu"]
+  spec.email         = ["cdmicacc@gmail.com", "zimu@500px.com"]
   spec.homepage      = ""
   spec.license       = "MIT"
 

--- a/spec/px/service/client/future_spec.rb
+++ b/spec/px/service/client/future_spec.rb
@@ -226,4 +226,27 @@ describe Px::Service::Client::Future do
       end
     end
   end
+
+  describe '#initialize' do
+    context 'when a block is given' do
+      context 'when the block returns a value' do
+        let(:value) { rand }
+
+        subject { Px::Service::Client::Future.new { value } }
+
+        it 'passes the value to the pending call' do
+          expect(subject.value).to eq(value)
+        end
+      end
+
+      context 'when the block throws an error' do
+        let(:error) { RuntimeError.new('error') }
+        subject { Px::Service::Client::Future.new { raise error } }
+
+        it 'passes the error to the pending call' do
+          expect(subject.value).to eq(error)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
We noticed `AlreadyCompletedError` is raised when some error occurs in the main code path, e.g., 
```ruby
client = Px::Service::MyClient.new
response = client.get(...)
result = Px::Service::Client::Future.new do
  parsed_body(response)
end
result.value
raise 'some_error'
```
This unexpected error is due bad error handling in `Future`.

To fix this, any error raised in the main code path when `pending_call[:fiber].resume(result)` is executed (in `Future#complete`) should not be captured by `Future` instance. Such an error should be escalated through the original code path.